### PR TITLE
Add nodemailer-mandrill-transport to list of transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ transporter.sendMail({
   * **[nodemailer-stub-transport](https://github.com/andris9/nodemailer-stub-transport)** is just for returning messages, most probably for testing purposes
   * **[nodemailer-pickup-transport](https://github.com/andris9/nodemailer-pickup-transport)** for storing messages to pickup folders
   * **[nodemailer-sendgrid-transport](https://github.com/sendgrid/nodemailer-sendgrid-transport)** for sending messages through SendGrid's Web API
+  * **[nodemailer-mandrill-transport](https://github.com/rebelmail/nodemailer-mandrill-transport)** for sending messages through Mandrill's Web API
   * *add yours* (see transport api documentation [here](#transports))
 
 ## Available Plugins


### PR DESCRIPTION
This is a PR to add nodemailer-mandrill-transport to the list of transports. 

Thank you again for such a nice email middleware for the node world.